### PR TITLE
Solve issues from Goolge Chrome Accessibility Audit

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="no-js" lang="">
+<html class="no-js" lang="en">
 
 <head>
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-97195950-6"></script>


### PR DESCRIPTION
Running Google Chrome Accessibility Audit (Lighthouse) against https://emojipages.com/ shows that no `lang` attribute is set in the `html` element.
This makes it hard for screenreaders to detect the language of the content of the page properly.

This change adds the value `en` to the `lang` attribute.